### PR TITLE
[BUGFIX] - #537

### DIFF
--- a/src/features/nav/dialog/EnterInboxCodeDialog.js
+++ b/src/features/nav/dialog/EnterInboxCodeDialog.js
@@ -90,9 +90,7 @@ const EnterInboxCodeDialog = () => {
         {
           state.nav.dialogs.enterInboxCode.inbox
             ? <FormGroup>
-                <Alert severity="info">
-                  Both players can send a move to the shared correspondence inbox. Whose turn is it now to play?
-                </Alert>
+               
                 {
                   state.nav.dialogs.enterInboxCode.inbox.fen
                     ? <Card sx={{ mt: 2 }}>


### PR DESCRIPTION
Open the file src/features/nav/dialog/EnterInboxCodeDialog.js in your preferred text editor. Remove the lines related to the <Alert> tag that you've mentioned in your comment. Remove the following lines:
`<Alert severity="info">
  Both players can send a move to the shared correspondence inbox. Whose turn is it now to play?
</Alert>
`