### PR TITLE
[FIX]: Scroll to bottom implemented in HTML table

### DIFF
--- a/src/features/mode/rav/panel/RavMovesTable.js
+++ b/src/features/mode/rav/panel/RavMovesTable.js
@@ -3,11 +3,17 @@ import { Table, TableBody, TableCell, TableContainer, TableRow } from "@mui/mate
 import Movetext from 'common/Movetext.js';
 import * as panel from 'features/panel/panelSlice';
 import styles from 'styles/panel';
+import { useEffect, useRef } from 'react';
 
 const RavMovesTable = () => {
   const state = useSelector(state => state);
   
   const dispatch = useDispatch();
+  const movesTable = useRef(null);
+
+  useEffect(() => {
+    movesTable.current.scrollIntoView({ block: 'end' });
+  });
 
   const currentMove = (fen) => {
     if (state.board.fen.length - 1 + state.panel.history.back === fen ) {
@@ -98,7 +104,7 @@ const RavMovesTable = () => {
     return (
       <TableContainer sx={styles.panel.movesTable.tableContainer} className="noTextSelection">
         <Table stickyHeader size="small" aria-label="Movetext">
-          <TableBody>
+          <TableBody ref={movesTable}>
             {description()}
             {moves()}
           </TableBody>


### PR DESCRIPTION
Fixes: #582 

The HTML table in [src/features/mode/rav/panel/RavMovesTable.js](https://github.com/chesslablab/react-chess/blob/master/src/features/mode/rav/panel/RavMovesTable.js) is now automatically scrollable to the bottom to get the last move displayed.