### PR TITLE
add configurable chat iframe #687

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ REACT_APP_API_PORT=443
 REACT_APP_WS_SCHEME=wss
 REACT_APP_WS_HOST=pchess.net
 REACT_APP_WS_PORT=8443
+
+# Empty to disable iframe chat feature
+REACT_APP_IFRAME_CHAT_TITLE=ChesslaBlab Chat
+REACT_APP_IFRAME_CHAT_SRC=https://web.libera.chat/gamja/#chesslablab

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import Panel from 'features/panel/Panel';
 import Heuristics from 'features/Heuristics';
 import PositionEval from 'features/PositionEval';
 import ProgressDialog from 'features/ProgressDialog';
+import Iframe from 'features/Iframe';
 import theme from 'styles/theme.js';
 
 const App = () => {
@@ -36,7 +37,7 @@ const App = () => {
             <Panel />
           </Grid>
           <Grid item xs={12} md={3}>
-            <iframe title="ChesslaBlab Chat" src="https://web.libera.chat/gamja/#chesslablab"></iframe>
+            <Iframe title={process.env.REACT_APP_IFRAME_CHAT_TITLE} src={process.env.REACT_APP_IFRAME_CHAT_SRC} />
           </Grid>
         </Grid>
         <ModeFenDialogs />

--- a/src/features/Iframe.js
+++ b/src/features/Iframe.js
@@ -1,0 +1,12 @@
+const Iframe = ({ title, src }) => {
+
+    if (title && src) {
+        return (
+            <iframe title={title} src={src}></iframe>
+        );
+    }
+
+    return null;
+};
+
+export default Iframe;

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,7 @@ iframe {
   border: 0;
   width: 100%;
   width: -webkit-fill-available;
-  min-height: 482px;
-  height: 100%;
+  height: 482px;
 }
 
 .noTextSelection {

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,8 @@ iframe {
   border: 0;
   width: 100%;
   width: -webkit-fill-available;
-  height: 482px;
+  min-height: 482px;
+  height: 100%;
 }
 
 .noTextSelection {


### PR DESCRIPTION
Closes https://github.com/chesslablab/react-chess/issues/687

ps Iframe created as the separated node, could be useful for other needs, just not sure about it location in FS..

pps added 100% height because more useful for chat. I think that CSS better to assign to `.chat` class in future