### PR TITLE
add play online queue to side panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ REACT_APP_API_PORT=443
 REACT_APP_WS_SCHEME=wss
 REACT_APP_WS_HOST=pchess.net
 REACT_APP_WS_PORT=8443
+
+# Empty to disable iframe chat feature
+REACT_APP_IFRAME_CHAT_TITLE=ChesslaBlab Chat
+REACT_APP_IFRAME_CHAT_SRC=https://web.libera.chat/gamja/#chesslablab

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import Panel from 'features/panel/Panel';
 import Heuristics from 'features/Heuristics';
 import PositionEval from 'features/PositionEval';
 import ProgressDialog from 'features/ProgressDialog';
+import PlayOnlineTable from 'features/mode/play/table/PlayOnlineTable';
 import theme from 'styles/theme.js';
 
 const App = () => {
@@ -36,6 +37,7 @@ const App = () => {
             <Panel />
           </Grid>
           <Grid item xs={12} md={3}>
+            <PlayOnlineTable />
             <iframe title="ChesslaBlab Chat" src="https://web.libera.chat/gamja/#chesslablab"></iframe>
           </Grid>
         </Grid>

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import Heuristics from 'features/Heuristics';
 import PositionEval from 'features/PositionEval';
 import ProgressDialog from 'features/ProgressDialog';
 import PlayOnlineTable from 'features/mode/play/table/PlayOnlineTable';
+import Iframe from 'features/Iframe';
 import theme from 'styles/theme.js';
 
 const App = () => {
@@ -38,7 +39,7 @@ const App = () => {
           </Grid>
           <Grid item xs={12} md={3}>
             <PlayOnlineTable />
-            <iframe title="ChesslaBlab Chat" src="https://web.libera.chat/gamja/#chesslablab"></iframe>
+            <Iframe title={process.env.REACT_APP_IFRAME_CHAT_TITLE} src={process.env.REACT_APP_IFRAME_CHAT_SRC} />
           </Grid>
         </Grid>
         <ModeFenDialogs />

--- a/src/features/Iframe.js
+++ b/src/features/Iframe.js
@@ -1,0 +1,12 @@
+const Iframe = ({ title, src }) => {
+
+    if (title && src) {
+        return (
+            <iframe title={title} src={src}></iframe>
+        );
+    }
+
+    return null;
+};
+
+export default Iframe;

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,8 @@ iframe {
   border: 0;
   width: 100%;
   width: -webkit-fill-available;
-  height: 482px;
+  min-height: 482px;
+  height: 100%;
 }
 
 .noTextSelection {


### PR DESCRIPTION
I think it would be useful to add pending for online game queue into the side panel

This feature could be improved

Also we can drop deprecated Iframe #687, or merge with following PR https://github.com/chesslablab/react-chess/pull/689

With chat iframe
![Pasted image](https://github.com/chesslablab/react-chess/assets/108541346/0e415c62-be82-4b97-a470-00e356910750)

Without chat
![Pasted image 1](https://github.com/chesslablab/react-chess/assets/108541346/25a104b7-1e87-4c8b-a9b9-7a7514918787)

